### PR TITLE
La inn e-post regex validering for gyldig e-poster

### DIFF
--- a/src/App/Skjema/Side1/inputFeltValideringer.tsx
+++ b/src/App/Skjema/Side1/inputFeltValideringer.tsx
@@ -10,7 +10,8 @@ export const erGyldigTelefonNr = (nr: string) => {
 };
 
 export const erGyldigEpost = (epost: string) => {
-   
+
+    // kilde for regex https://emailregex.com (RFC 5322 Official Standard)
     const regexp = new RegExp(/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
     const isValidEmail = regexp.test(epost);
     


### PR DESCRIPTION
Fikser problemer som:
- inneholder ikke .no
- navn@navn@domene.com
- navn @domene.com (inneholder space)
- -no (dash istedenfor punktum)
- ugyldige tegn ($, €, £, osv)