### PR TITLE
Refusjon: litt strengere sjekk pa hva som er ubehandlede beregninger

### DIFF
--- a/src/App/Refusjon/Steg2-Arbeidsforhold/index.tsx
+++ b/src/App/Refusjon/Steg2-Arbeidsforhold/index.tsx
@@ -59,7 +59,7 @@ const Arbeidsforhold: FunctionComponent = () => {
     }, [context.skjema.id, hentOgSettArbeidsforhold]);
 
     const harUbehandledeBeregninger = arbeidsforhold.content.some(
-        a => !a.inntektInnhentet && !a.beregningsdetaljer.some(a => a === 'FEILET')
+        a => !a.inntektInnhentet && !a.beregningsdetaljer.includes('FEILET')
     );
     const fetchIntervallArbeidsforhold = harUbehandledeBeregninger ? 2_000 : 60_000;
     useInterval(hentOgSettArbeidsforhold, fetchIntervallArbeidsforhold);


### PR DESCRIPTION
Når en beregning har fått status so `Feilet` vil den ikke ha `inntektInnhentet` og sjekken for å gjøre kall hvert andre sekund vil alltid slå ut. 
Sjekker derfor at den ikke har status som feilet også