### PR TITLE
Endret søk på stillingstitler til å gå direkte mot service

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -43,7 +43,7 @@ jobs:
 
   deploy-to-dev-gcp:
     name: Deploy to dev-gcp
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stillingstitle-tmp-fix'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/yrkestitler-via-svc'
     needs: compile-test-and-build
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   deploy-to-labs-gcp:
     name: Deploy to labs-gcp
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stillingstitle-tmp-fix'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/yrkestitler-via-svc'
     needs: compile-test-and-build
     runs-on: ubuntu-latest
     steps:

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -32,10 +32,11 @@ spec:
     outbound:
       rules:
         - application: permittering-redis
+        - application: pam-janzz
+          namespace: teampam
       external:
         - host: dekoratoren.dev.nav.no
         - host: arbeidsgiver-permitteringsskjema-api.dev-fss-pub.nais.io
-        - host: pam-janzz.intern.nav.no
   envFrom:
     - secret: permittering-redis-secrets
     - secret: permittering-secrets

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -32,10 +32,11 @@ spec:
     outbound:
       rules:
         - application: permittering-redis
+        - application: pam-janzz
+          namespace: teampam
       external:
         - host: dekoratoren.nav.no
         - host: arbeidsgiver-permitteringsskjema-api.prod-fss-pub.nais.io
-        - host: pam-janzz.intern.nav.no
   envFrom:
     - secret: permittering-redis-secrets
     - secret: permittering-secrets

--- a/src/server/routes/router.js
+++ b/src/server/routes/router.js
@@ -19,7 +19,7 @@ const getConfiguredRouter = (tokenXClient, tokenXIssuer, idPortenEndSession) => 
     indexRoute(app);
     app.use(
         paths.stillingstitlerPath,
-        proxy('https://pam-janzz.intern.nav.no', {
+        proxy('http://pam-janzz.teampam', {
             proxyReqPathResolver: (req) => {
                 return `/pam-janzz/rest/typeahead/yrke-med-styrk08-nav${req.url}`;
             },


### PR DESCRIPTION
Går mot service isteden for å gå mot ingress. Dette er foretrukket løsning da team som håndterer yrkeskategorier vet at vi en en konsument av api.